### PR TITLE
workflows: Remove caching from build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,19 +73,6 @@ jobs:
           php-version: '8.3'
           coverage: none
 
-      - name: Get composer cache directory
-        id: composer-cache
-        shell: bash
-        run: |
-          echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache composer cache directory
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
       - name: Run composer
         run: composer install --no-dev --optimize-autoloader
 


### PR DESCRIPTION
Removes caching from build action to prevent compromised releases via cache poisoning.